### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Your [contributions](contributing.md) are always welcome !
 - [KoviD kernel rootkit](https://github.com/carloslack/KoviD)
 - [Offensive capabilities of eBPF and implementation of a rootkit](https://raw.githubusercontent.com/h3xduck/TripleCross/master/docs/ebpf_offensive_rootkit_tfg.pdf)
 - [debugoff - linux anti-debugging and anti-analysis rust library](https://github.com/0xor0ne/debugoff)
-- [ELF Binaries: One Algorithm to Infect Them All (VXUG Black Mass Volume II)](https://samples.vx-underground.org/root/Papers/Other/VXUG%20Zines/2023-09-19%20-%20Black%20Mass%20Volume%20II.pdf)
+- [ELF Binaries: One Algorithm to Infect Them All (VXUG Black Mass Volume II)](https://samples.vx-underground.org/Papers/Other/VXUG%20Zines/2023-09-19%20-%20Black%20Mass%20Volume%20II.pdf)
 - [grugq & scut: Armouring the ELF: Binary encryption on the UNIX platform](https://grugq.github.io/docs/phrack-58-05.txt)
 - [sblip & elfmaster: Secure Code Partitioning With ELF binaries, aka. SCOP](https://bitlackeys.org/papers/secure_code_partitioning_2018.txt) ([mirror](txt/sblip_elfmaster_scop.txt))
 


### PR DESCRIPTION
A change in VXUG web platform produced a broken link for Black Mass Volume II. This commit fixes that.